### PR TITLE
feat: use Donut graph for today view (with unused)

### DIFF
--- a/front/.vscode/settings.json
+++ b/front/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "files.associations": { "*.js": "javascript" }
+}

--- a/front/package.json
+++ b/front/package.json
@@ -116,7 +116,6 @@
       "src/**/*.{js,jsx,mjs}"
     ],
     "setupFiles": [
-      "<rootDir>/config/polyfills.js",
       "<rootDir>/tests/setup.js"
     ],
     "testMatch": [
@@ -157,5 +156,8 @@
       "@semantic-release/npm",
       "@semantic-release/git"
     ]
+  },
+  "devDependencies": {
+    "@types/jest": "^26.0.22"
   }
 }

--- a/front/package.json
+++ b/front/package.json
@@ -16,6 +16,7 @@
     "@material-ui/icons": "^4.5.1",
     "@material-ui/lab": "^4.0.0-alpha.39",
     "@material-ui/pickers": "^3.2.10",
+    "@reduxjs/toolkit": "^1.5.1",
     "@semantic-release/changelog": "^5.0.1",
     "@semantic-release/git": "^9.0.0",
     "@types/react-loadable": "^5.5.4",

--- a/front/src/common/minsToHoursMinutes.js
+++ b/front/src/common/minsToHoursMinutes.js
@@ -13,7 +13,7 @@ function minsToHoursMinutes(minutes) {
  * @param {number} ms
  */
 export function msToHoursMinutes(ms) {
-  return minsToHoursMinutes(ms / 60000);
+  return minsToHoursMinutes(Math.floor(ms / 60000));
 }
 
 export default minsToHoursMinutes;

--- a/front/src/common/minsToHoursMinutes.js
+++ b/front/src/common/minsToHoursMinutes.js
@@ -8,4 +8,12 @@ function minsToHoursMinutes(minutes) {
   return `${hours}:${mins.toString().padStart(2, '0')}`;
 }
 
+/**
+ * convert milliseconds into hours:minutes format
+ * @param {number} ms
+ */
+export function msToHoursMinutes(ms) {
+  return minsToHoursMinutes(ms / 60000);
+}
+
 export default minsToHoursMinutes;

--- a/front/src/common/noop.js
+++ b/front/src/common/noop.js
@@ -1,0 +1,5 @@
+/**
+ * Does nothing
+ * @param {*} args
+ */
+export function noop(args) {}

--- a/front/src/features/home/redux/diffDateStrings.js
+++ b/front/src/features/home/redux/diffDateStrings.js
@@ -1,0 +1,14 @@
+/**
+ * Given to dates as ISO strings return the difference between them
+ * or 0 if the second date is not defined.
+ * Can be used to calculate durations
+ * @param {string} start
+ * @param {string} [ end ]
+ * @return {number}
+ */
+export function diffDateStrings(start, end) {
+  if (!end) return 0;
+  const a = new Date(start);
+  const b = new Date(end);
+  return b.getTime() - a.getTime();
+}

--- a/front/src/features/home/redux/selectGroupedSessions.js
+++ b/front/src/features/home/redux/selectGroupedSessions.js
@@ -2,19 +2,9 @@
 /** @typedef {{[k: string]: SessionGroup | undefined }} Grouped */
 
 import { createSelector } from 'reselect';
+import { diffDateStrings } from './diffDateStrings';
 import selectSessions from './selectSessions';
 
-/**
- * @param {string} start
- * @param {string} [ end ]
- * @return {number}
- */
-function diffDateStrings(start, end) {
-  if (!end) return 0;
-  const a = new Date(start);
-  const b = new Date(end);
-  return b.getTime() - a.getTime();
-}
 function getTodayISO() {
   const today = new Date();
   today.setUTCHours(0, 0, 0, 0);

--- a/front/src/features/stats/Chart.js
+++ b/front/src/features/stats/Chart.js
@@ -14,6 +14,7 @@ import {
 import Title from './Title';
 import PropTypes from 'prop-types';
 import { stringToColour } from './stringToColour';
+import { noop } from '@common/noop';
 
 /**
  * @param {{ sessions: import('../../types').Session[],
@@ -65,7 +66,7 @@ export default function Chart({ sessions, title, names, formatter }) {
  * names: ['task1','task2']
  */
 Chart.propTypes = {
-  title: PropTypes.string,
+  title: PropTypes.node,
   names: PropTypes.arrayOf(PropTypes.string).isRequired,
   formatter: PropTypes.func,
   sessions: PropTypes.arrayOf(
@@ -76,5 +77,5 @@ Chart.propTypes = {
 };
 Chart.defaultProps = {
   sessions: [],
-  formatter: i => i,
+  formatter: noop,
 };

--- a/front/src/features/stats/Dashboard.js
+++ b/front/src/features/stats/Dashboard.js
@@ -7,18 +7,14 @@ import Grid from '@material-ui/core/Grid';
 import Paper from '@material-ui/core/Paper';
 import Chart from './Chart';
 import { createChartData } from './createChartData';
-import IconButton from '@material-ui/core/Button';
-import NavigateNextIcon from '@material-ui/icons/NavigateNext';
-import NavigateBeforeIcon from '@material-ui/icons/NavigateBefore';
-import Typography from '@material-ui/core/Typography';
-import format from 'date-fns/format';
-import subDays from 'date-fns/subDays';
 import minsToHoursMinutes from '../../common/minsToHoursMinutes';
 import { FooterWithVersion } from '../common/index';
 import DonutContainer from './Donut.container';
+import { DaysNavigator, WeeksNavigator } from './NavigationControls';
+import { useNavigateWeeks } from './redux/navigateWeeks';
 const drawerWidth = 240;
 
-const useStyles = makeStyles(theme => ({
+export const useStyles = makeStyles(theme => ({
   root: {
     display: 'flex',
   },
@@ -75,49 +71,6 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-/** @typedef {Object} PropsA
- * @property {(n:number) => any} setValue
- * @property {never} [ baseName ]
- * @property {never} [ unit ]
- * @property {string} text
- * @property {number} value
- */
-/** @typedef {Object} PropsB
- * @property {(n:number) => any} setValue
- * @property {string} baseName
- * @property {string} unit
- * @property {never} [ text ]
- * @property {number} value
- */
-
-/**
- * @param {PropsA|PropsB} props
- */
-function NavigationControls({ setValue, baseName, value, text, unit }) {
-  // @ts-ignore
-  const { navigation } = useStyles();
-  const back = () => setValue(value + 1);
-  const next = () => setValue(value - 1);
-  return (
-    <div className={navigation}>
-      <IconButton onClick={back}>
-        <NavigateBeforeIcon />
-      </IconButton>
-      <Typography variant="button" align="center">
-        {text || (value === 0 ? baseName : `${value} ${unit} ago`)}
-      </Typography>
-      <IconButton onClick={next} disabled={value === 0}>
-        <NavigateNextIcon />
-      </IconButton>
-    </div>
-  );
-}
-
-/**
- * @param {number} ago
- */
-const formatDaysAgo = ago => (ago > 0 ? format(subDays(new Date(), ago), 'E d MMM') : 'Today');
-
 /** @typedef {import('@types').SessionWithDuration} SessionWithDuration */
 /**
  * @param {{ sessions: import('@types').Session[]  }} args
@@ -126,15 +79,13 @@ const formatDaysAgo = ago => (ago > 0 ? format(subDays(new Date(), ago), 'E d MM
 export default function Dashboard({ sessions = [] }) {
   // @ts-ignore
   const classes = useStyles();
-  const [daysAgo, setDay] = React.useState(0);
-  const [weeksAgo, setWeek] = React.useState(0);
+  const { weeksAgo } = useNavigateWeeks();
   const [monthsAgo /*, setMonth*/] = React.useState(0);
 
   const fixedHeightPaper = clsx(classes.paper, classes.fixedHeight);
 
   const { weekData, monthData } = createChartData({
     sessions,
-    daysAgo,
     weeksAgo,
     monthsAgo,
   });
@@ -147,16 +98,7 @@ export default function Dashboard({ sessions = [] }) {
             {/* Day */}
             <Grid item xs={12} md={6}>
               <Paper className={fixedHeightPaper}>
-                <DonutContainer
-                  daysAgo={daysAgo}
-                  title={
-                    <NavigationControls
-                      value={daysAgo}
-                      setValue={setDay}
-                      text={formatDaysAgo(daysAgo)}
-                    />
-                  }
-                />
+                <DonutContainer title={<DaysNavigator />} />
               </Paper>
             </Grid>
             {/* Week */}
@@ -166,14 +108,7 @@ export default function Dashboard({ sessions = [] }) {
                   formatter={minsToHoursMinutes}
                   sessions={weekData.data}
                   names={weekData.names}
-                  title={
-                    <NavigationControls
-                      value={weeksAgo}
-                      setValue={setWeek}
-                      baseName="this week"
-                      unit="weeks"
-                    />
-                  }
+                  title={<WeeksNavigator />}
                 />
               </Paper>
             </Grid>

--- a/front/src/features/stats/Dashboard.js
+++ b/front/src/features/stats/Dashboard.js
@@ -12,6 +12,7 @@ import { FooterWithVersion } from '../common/index';
 import DonutContainer from './Donut.container';
 import { DaysNavigator } from './NavigationControls';
 import WeekChart from './WeekChart';
+import MonthChart from './MonthChart';
 const drawerWidth = 240;
 
 export const useStyles = makeStyles(theme => ({
@@ -76,18 +77,11 @@ export const useStyles = makeStyles(theme => ({
  * @param {{ sessions: import('@types').Session[]  }} args
  * @return {*}
  */
-export default function Dashboard({ sessions = [] }) {
+export default function Dashboard() {
   // @ts-ignore
   const classes = useStyles();
-  const monthsAgo = 0;
 
   const fixedHeightPaper = clsx(classes.paper, classes.fixedHeight);
-
-  const { monthData } = createChartData({
-    sessions,
-    weeksAgo: 0,
-    monthsAgo,
-  });
 
   return (
     <div className={classes.root}>
@@ -109,12 +103,7 @@ export default function Dashboard({ sessions = [] }) {
             {/* Month */}
             <Grid item xs={12}>
               <Paper className={fixedHeightPaper}>
-                <Chart
-                  formatter={minsToHoursMinutes}
-                  title="Month"
-                  names={monthData.names}
-                  sessions={monthData.data}
-                />
+                <MonthChart />
               </Paper>
             </Grid>
           </Grid>

--- a/front/src/features/stats/Dashboard.js
+++ b/front/src/features/stats/Dashboard.js
@@ -5,9 +5,6 @@ import Box from '@material-ui/core/Box';
 import Container from '@material-ui/core/Container';
 import Grid from '@material-ui/core/Grid';
 import Paper from '@material-ui/core/Paper';
-import Chart from './Chart';
-import { createChartData } from './createChartData';
-import minsToHoursMinutes from '../../common/minsToHoursMinutes';
 import { FooterWithVersion } from '../common/index';
 import DonutContainer from './Donut.container';
 import { DaysNavigator } from './NavigationControls';
@@ -73,10 +70,6 @@ export const useStyles = makeStyles(theme => ({
 }));
 
 /** @typedef {import('@types').SessionWithDuration} SessionWithDuration */
-/**
- * @param {{ sessions: import('@types').Session[]  }} args
- * @return {*}
- */
 export default function Dashboard() {
   // @ts-ignore
   const classes = useStyles();

--- a/front/src/features/stats/Dashboard.js
+++ b/front/src/features/stats/Dashboard.js
@@ -11,7 +11,7 @@ import minsToHoursMinutes from '../../common/minsToHoursMinutes';
 import { FooterWithVersion } from '../common/index';
 import DonutContainer from './Donut.container';
 import { DaysNavigator } from './NavigationControls';
-import MonthChart from './MonthChart';
+import WeekChart from './WeekChart';
 const drawerWidth = 240;
 
 export const useStyles = makeStyles(theme => ({
@@ -103,7 +103,7 @@ export default function Dashboard({ sessions = [] }) {
             {/* Week */}
             <Grid item xs={12} md={6}>
               <Paper className={fixedHeightPaper}>
-                <MonthChart />
+                <WeekChart />
               </Paper>
             </Grid>
             {/* Month */}

--- a/front/src/features/stats/Dashboard.js
+++ b/front/src/features/stats/Dashboard.js
@@ -15,6 +15,7 @@ import format from 'date-fns/format';
 import subDays from 'date-fns/subDays';
 import minsToHoursMinutes from '../../common/minsToHoursMinutes';
 import { FooterWithVersion } from '../common/index';
+import DonutContainer from './Donut.container';
 const drawerWidth = 240;
 
 const useStyles = makeStyles(theme => ({
@@ -103,7 +104,6 @@ function NavigationControls({ setValue, baseName, value, text, unit }) {
         <NavigateBeforeIcon />
       </IconButton>
       <Typography variant="button" align="center">
-        {' '}
         {text || (value === 0 ? baseName : `${value} ${unit} ago`)}
       </Typography>
       <IconButton onClick={next} disabled={value === 0}>
@@ -118,8 +118,9 @@ function NavigationControls({ setValue, baseName, value, text, unit }) {
  */
 const formatDaysAgo = ago => (ago > 0 ? format(subDays(new Date(), ago), 'E d MMM') : 'Today');
 
+/** @typedef {import('@types').SessionWithDuration} SessionWithDuration */
 /**
- * @param {{ sessions: import('../../types').Session[]}} args
+ * @param {{ sessions: import('@types').Session[]  }} args
  * @return {*}
  */
 export default function Dashboard({ sessions = [] }) {
@@ -131,7 +132,7 @@ export default function Dashboard({ sessions = [] }) {
 
   const fixedHeightPaper = clsx(classes.paper, classes.fixedHeight);
 
-  const { dayData, weekData, monthData } = createChartData({
+  const { weekData, monthData } = createChartData({
     sessions,
     daysAgo,
     weeksAgo,
@@ -146,9 +147,8 @@ export default function Dashboard({ sessions = [] }) {
             {/* Day */}
             <Grid item xs={12} md={6}>
               <Paper className={fixedHeightPaper}>
-                <Chart
-                  sessions={dayData.data}
-                  names={dayData.names}
+                <DonutContainer
+                  daysAgo={daysAgo}
                   title={
                     <NavigationControls
                       value={daysAgo}

--- a/front/src/features/stats/Dashboard.js
+++ b/front/src/features/stats/Dashboard.js
@@ -10,8 +10,8 @@ import { createChartData } from './createChartData';
 import minsToHoursMinutes from '../../common/minsToHoursMinutes';
 import { FooterWithVersion } from '../common/index';
 import DonutContainer from './Donut.container';
-import { DaysNavigator, WeeksNavigator } from './NavigationControls';
-import { useNavigateWeeks } from './redux/navigateWeeks';
+import { DaysNavigator } from './NavigationControls';
+import MonthChart from './MonthChart';
 const drawerWidth = 240;
 
 export const useStyles = makeStyles(theme => ({
@@ -79,14 +79,13 @@ export const useStyles = makeStyles(theme => ({
 export default function Dashboard({ sessions = [] }) {
   // @ts-ignore
   const classes = useStyles();
-  const { weeksAgo } = useNavigateWeeks();
   const monthsAgo = 0;
 
   const fixedHeightPaper = clsx(classes.paper, classes.fixedHeight);
 
-  const { weekData, monthData } = createChartData({
+  const { monthData } = createChartData({
     sessions,
-    weeksAgo,
+    weeksAgo: 0,
     monthsAgo,
   });
 
@@ -104,12 +103,7 @@ export default function Dashboard({ sessions = [] }) {
             {/* Week */}
             <Grid item xs={12} md={6}>
               <Paper className={fixedHeightPaper}>
-                <Chart
-                  formatter={minsToHoursMinutes}
-                  sessions={weekData.data}
-                  names={weekData.names}
-                  title={<WeeksNavigator />}
-                />
+                <MonthChart />
               </Paper>
             </Grid>
             {/* Month */}

--- a/front/src/features/stats/Dashboard.js
+++ b/front/src/features/stats/Dashboard.js
@@ -80,7 +80,7 @@ export default function Dashboard({ sessions = [] }) {
   // @ts-ignore
   const classes = useStyles();
   const { weeksAgo } = useNavigateWeeks();
-  const [monthsAgo /*, setMonth*/] = React.useState(0);
+  const monthsAgo = 0;
 
   const fixedHeightPaper = clsx(classes.paper, classes.fixedHeight);
 

--- a/front/src/features/stats/DefaultPage.js
+++ b/front/src/features/stats/DefaultPage.js
@@ -2,32 +2,21 @@ import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import { fetchSessions } from '../home/redux/actions';
 import Dashboard from './Dashboard';
-import selectAllSessions from '../home/redux/selectAllSessions';
-
-/**
- * @param {import('rootReducer').RootState} state
- */
-function mapStateToProps(state) {
-  return {
-    stats: state.stats,
-    sessions: selectAllSessions(state),
-  };
-}
 
 const mapDispatchToProps = {
   fetchSessions,
 };
 
-const connector = connect(mapStateToProps, mapDispatchToProps);
+const connector = connect(null, mapDispatchToProps);
 
 /**
  * @param {import('react-redux').ConnectedProps<typeof connector>} Props
  */
-function StatsDefaultPage({ fetchSessions, sessions }) {
+function StatsDefaultPage({ fetchSessions }) {
   useEffect(() => {
     fetchSessions();
   }, []);
-  return <Dashboard sessions={sessions} />;
+  return <Dashboard />;
 }
 
 export default connector(StatsDefaultPage);

--- a/front/src/features/stats/Donut.container.js
+++ b/front/src/features/stats/Donut.container.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+import Donut from './Donut';
+import selectDonutSessions from './redux/selectDonutSessions';
+
+/**
+ * @typedef {import('rootReducer').RootState} State
+ */
+
+/**
+ * @typedef {Object} Props
+ * @property {number} daysAgo
+ * @property {any} title
+ */
+
+/** @param {Props} props **/
+export default function DonutContainer({ daysAgo, title }) {
+  const sessions = useSelector(
+    /** @param {State} state */
+    state => {
+      return selectDonutSessions(state, daysAgo);
+    },
+  );
+  return <Donut sessions={sessions} title={title} />;
+}

--- a/front/src/features/stats/Donut.container.js
+++ b/front/src/features/stats/Donut.container.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { useSelector } from 'react-redux';
 import Donut from './Donut';
 import selectDonutSessions from './redux/selectDonutSessions';
+import selectWeekChartData from './redux/selectWeekChartData';
 
 /**
  * @typedef {import('rootReducer').RootState} State
@@ -17,6 +18,7 @@ export default function DonutContainer({ title }) {
   const sessions = useSelector(
     /** @param {State} state */
     state => {
+      console.log(selectWeekChartData(state));
       return selectDonutSessions(state, state.stats.daysAgo);
     },
   );

--- a/front/src/features/stats/Donut.container.js
+++ b/front/src/features/stats/Donut.container.js
@@ -9,16 +9,15 @@ import selectDonutSessions from './redux/selectDonutSessions';
 
 /**
  * @typedef {Object} Props
- * @property {number} daysAgo
  * @property {any} title
  */
 
 /** @param {Props} props **/
-export default function DonutContainer({ daysAgo, title }) {
+export default function DonutContainer({ title }) {
   const sessions = useSelector(
     /** @param {State} state */
     state => {
-      return selectDonutSessions(state, daysAgo);
+      return selectDonutSessions(state, state.stats.daysAgo);
     },
   );
   return <Donut sessions={sessions} title={title} />;

--- a/front/src/features/stats/Donut.js
+++ b/front/src/features/stats/Donut.js
@@ -1,0 +1,71 @@
+import React from 'react';
+import { ResponsiveContainer, PieChart, Pie, Cell } from 'recharts';
+import Title from './Title';
+import PropTypes from 'prop-types';
+import { stringToColour } from './stringToColour';
+import { noop } from 'common/noop';
+import { msToHuman } from 'formatters/formatDateDiff';
+
+/**
+ * @param {{name: string, duration: number }} param
+ */
+function getName({ name, duration }) {
+  return `${name} - ${msToHuman(duration)}`;
+}
+
+/**
+ * @param {{ sessions: { name: string, duration: number }[],
+ *           title: React.ReactChild,
+ *          }} props
+ */
+export default function Donut({ sessions, title }) {
+  return (
+    <React.Fragment>
+      <Title>{title}</Title>
+      <ResponsiveContainer height="100%">
+        <PieChart
+          margin={{
+            top: 16,
+            right: 16,
+            bottom: 0,
+            left: 10,
+          }}
+        >
+          <Pie
+            data={sessions}
+            dataKey="duration"
+            nameKey="name"
+            innerRadius={60}
+            outerRadius={80}
+            // @ts-ignore it actually accepts a function, types are wrong
+            label={getName}
+            // label
+          >
+            {sessions.map(({ name }) => (
+              <Cell key={name} fill={stringToColour(name)} />
+            ))}
+          </Pie>
+        </PieChart>
+      </ResponsiveContainer>
+    </React.Fragment>
+  );
+}
+/**
+ * The expected shape of the data is
+ * sessions: {startDAte: String, task1: duration, task2: duration}
+ * names: ['task1','task2']
+ */
+Donut.propTypes = {
+  title: PropTypes.element,
+  formatter: PropTypes.func,
+  sessions: PropTypes.arrayOf(
+    PropTypes.shape({
+      name: PropTypes.string,
+      duration: PropTypes.number,
+    }),
+  ),
+};
+Donut.defaultProps = {
+  sessions: [],
+  formatter: noop,
+};

--- a/front/src/features/stats/Donut.js
+++ b/front/src/features/stats/Donut.js
@@ -39,7 +39,7 @@ export default function Donut({ sessions, title }) {
             outerRadius={80}
             // @ts-ignore it actually accepts a function, types are wrong
             label={getName}
-            // label
+            paddingAngle={4}
           >
             {sessions.map(({ name }) => (
               <Cell key={name} fill={stringToColour(name)} />

--- a/front/src/features/stats/MonthChart.js
+++ b/front/src/features/stats/MonthChart.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+import Chart from './Chart';
+import selectMonthChartData from './redux/selectMonthChartData';
+import { msToHoursMinutes } from '@common/minsToHoursMinutes';
+
+/**
+ * @typedef {import('rootReducer').RootState} State
+ */
+
+export default function MonthChart() {
+  const { names, sessions } = useSelector(
+    /** @param {State} state */
+    state => {
+      return selectMonthChartData(state);
+    },
+  );
+  return <Chart formatter={msToHoursMinutes} sessions={sessions} names={names} title="Month" />;
+}

--- a/front/src/features/stats/MonthChart.js
+++ b/front/src/features/stats/MonthChart.js
@@ -1,0 +1,22 @@
+import { msToHuman } from 'formatters/formatDateDiff';
+import React from 'react';
+import { useSelector } from 'react-redux';
+import Chart from './Chart';
+import selectWeekChartData from './redux/selectWeekChartData';
+import { WeeksNavigator } from './NavigationControls';
+
+/**
+ * @typedef {import('rootReducer').RootState} State
+ */
+
+export default function MonthChart() {
+  const { names, sessions } = useSelector(
+    /** @param {State} state */
+    state => {
+      return selectWeekChartData(state);
+    },
+  );
+  return (
+    <Chart formatter={msToHuman} sessions={sessions} names={names} title={<WeeksNavigator />} />
+  );
+}

--- a/front/src/features/stats/NavigationControls.js
+++ b/front/src/features/stats/NavigationControls.js
@@ -1,0 +1,102 @@
+import React from 'react';
+import IconButton from '@material-ui/core/Button';
+import NavigateNextIcon from '@material-ui/icons/NavigateNext';
+import NavigateBeforeIcon from '@material-ui/icons/NavigateBefore';
+import Typography from '@material-ui/core/Typography';
+import { useStyles } from './Dashboard';
+import format from 'date-fns/format';
+import subDays from 'date-fns/subDays';
+import { useNavigateDays } from './redux/navigateDays';
+import { useNavigateWeeks } from './redux/navigateWeeks';
+
+/** @typedef {Object} PropsA
+ * @property {() => any} next
+ * @property {() => any} back
+ * @property {never} [ baseName ]
+ * @property {never} [ unit ]
+ * @property {string} text
+ * @property {number} value
+ */
+/** @typedef {Object} PropsB
+ * @property {() => any} next
+ * @property {() => any} back
+ * @property {string} baseName
+ * @property {string} unit
+ * @property {never} [ text ]
+ * @property {number} value
+ */
+/**
+ * @param {PropsA|PropsB} props
+ */
+function NavigationControlsBase({ next, back, baseName, value, text, unit }) {
+  // @ts-ignore
+  const { navigation } = useStyles();
+  return (
+    <div className={navigation}>
+      <IconButton onClick={back}>
+        <NavigateBeforeIcon />
+      </IconButton>
+      <Typography variant="button" align="center">
+        {text || (value === 0 ? baseName : `${value} ${unit} ago`)}
+      </Typography>
+      <IconButton onClick={next} disabled={value === 0}>
+        <NavigateNextIcon />
+      </IconButton>
+    </div>
+  );
+}
+/** @typedef {Object} NPropsA
+ * @property {(n:number) => any} setValue
+ * @property {never} [ baseName ]
+ * @property {never} [ unit ]
+ * @property {string} text
+ * @property {number} value
+ */
+/** @typedef {Object} NPropsB
+ * @property {(n:number) => any} setValue
+ * @property {string} baseName
+ * @property {string} unit
+ * @property {never} [ text ]
+ * @property {number} value
+ */
+/**
+ * @param {NPropsA|NPropsB} props
+ */
+export function NavigationControls({ setValue, baseName, value, text, unit }) {
+  const back = () => setValue(value + 1);
+  const next = () => setValue(value - 1);
+  return (
+    <NavigationControlsBase
+      baseName={baseName}
+      next={next}
+      back={back}
+      value={value}
+      text={text}
+      unit={unit}
+    />
+  );
+}
+
+/**
+ * @param {number} ago
+ */
+const formatDaysAgo = ago => (ago > 0 ? format(subDays(new Date(), ago), 'E d MMM') : 'Today');
+
+export function DaysNavigator() {
+  const { nextDay, previousDay, daysAgo } = useNavigateDays();
+  const text = formatDaysAgo(daysAgo);
+  return <NavigationControlsBase value={daysAgo} next={previousDay} back={nextDay} text={text} />;
+}
+
+export function WeeksNavigator() {
+  const { nextWeek, previousWeek, weeksAgo } = useNavigateWeeks();
+  return (
+    <NavigationControlsBase
+      value={weeksAgo}
+      next={previousWeek}
+      back={nextWeek}
+      baseName="this week"
+      unit="weeks"
+    />
+  );
+}

--- a/front/src/features/stats/NavigationControls.js
+++ b/front/src/features/stats/NavigationControls.js
@@ -45,37 +45,6 @@ function NavigationControlsBase({ next, back, baseName, value, text, unit }) {
     </div>
   );
 }
-/** @typedef {Object} NPropsA
- * @property {(n:number) => any} setValue
- * @property {never} [ baseName ]
- * @property {never} [ unit ]
- * @property {string} text
- * @property {number} value
- */
-/** @typedef {Object} NPropsB
- * @property {(n:number) => any} setValue
- * @property {string} baseName
- * @property {string} unit
- * @property {never} [ text ]
- * @property {number} value
- */
-/**
- * @param {NPropsA|NPropsB} props
- */
-export function NavigationControls({ setValue, baseName, value, text, unit }) {
-  const back = () => setValue(value + 1);
-  const next = () => setValue(value - 1);
-  return (
-    <NavigationControlsBase
-      baseName={baseName}
-      next={next}
-      back={back}
-      value={value}
-      text={text}
-      unit={unit}
-    />
-  );
-}
 
 /**
  * @param {number} ago

--- a/front/src/features/stats/WeekChart.js
+++ b/front/src/features/stats/WeekChart.js
@@ -9,7 +9,7 @@ import { WeeksNavigator } from './NavigationControls';
  * @typedef {import('rootReducer').RootState} State
  */
 
-export default function MonthChart() {
+export default function WeekChart() {
   const { names, sessions } = useSelector(
     /** @param {State} state */
     state => {

--- a/front/src/features/stats/createChartData.js
+++ b/front/src/features/stats/createChartData.js
@@ -1,15 +1,13 @@
-import subDays from 'date-fns/subDays';
 import subWeeks from 'date-fns/subWeeks';
 import subMonths from 'date-fns/subMonths';
 import endOfDay from 'date-fns/endOfDay';
-import startOfDay from 'date-fns/startOfDay';
 import startOfWeek from 'date-fns/startOfWeek';
 import endOfWeek from 'date-fns/endOfWeek';
 import startOfMonth from 'date-fns/startOfMonth';
 import isWithinInterval from 'date-fns/isWithinInterval';
 import format from 'date-fns/fp/format';
 import differenceInMinutes from 'date-fns/differenceInMinutes';
-/** @typedef {import('../../types').Session} Session*/
+/** @typedef {import('@types').Session} Session*/
 /** @typedef {{ startDate: string, [name: string]: number|string }}  Row hashmap of name-value indexed by formatted date**/
 /** @typedef {{names: Set<string>, [date:string]: Row|Set<string> }} MapRow **/
 /**
@@ -36,7 +34,6 @@ export const addToRow = (formatter, diffCalc) => (map, { name, startDate, endDat
   };
 };
 
-const makeDayRow = addToRow(format('HH:mm'), differenceInMinutes);
 const makeWeekRow = addToRow(format('E do MMM'), differenceInMinutes);
 const makeMonthRow = addToRow(format('Io'), differenceInMinutes);
 
@@ -49,13 +46,10 @@ const omitNamesProp = ({ names, ...rest }) => rest;
 
 /**
  *
- * @param {{ daysAgo: number, weeksAgo: number , monthsAgo: number, sessions: import('../../types').Session[]} } args
+ * @param {{  weeksAgo: number , monthsAgo: number, sessions: import('../../types').Session[]} } args
  */
-export function createChartData({ daysAgo, weeksAgo = 0, monthsAgo = 0, sessions }) {
+export function createChartData({ weeksAgo = 0, monthsAgo = 0, sessions }) {
   const today = endOfDay(new Date());
-
-  const dayRef = subDays(today, daysAgo);
-  const dayInterval = { start: startOfDay(dayRef), end: endOfDay(dayRef) };
 
   const weekRef = subWeeks(startOfWeek(today), weeksAgo);
   const weekInterval = { start: weekRef, end: endOfWeek(weekRef) };
@@ -66,7 +60,6 @@ export function createChartData({ daysAgo, weeksAgo = 0, monthsAgo = 0, sessions
   const chartData = sessions.reduce(
     (acc, session) => {
       const d = new Date(session.startDate);
-      if (isWithinInterval(d, dayInterval)) acc.d = makeDayRow(acc.d, session);
       if (isWithinInterval(d, weekInterval)) acc.w = makeWeekRow(acc.w, session);
       if (isWithinInterval(d, monthInterval)) acc.m = makeMonthRow(acc.m, session);
       return acc; // I don't usually mutate, but this is a big performance gain on this case
@@ -75,7 +68,6 @@ export function createChartData({ daysAgo, weeksAgo = 0, monthsAgo = 0, sessions
   ); // I was originally using longer names, but I think this is obvious
 
   return {
-    dayData: { data: Object.values(omitNamesProp(chartData.d)), names: [...chartData.d.names] },
     weekData: { data: Object.values(omitNamesProp(chartData.w)), names: [...chartData.w.names] },
     monthData: { data: Object.values(omitNamesProp(chartData.m)), names: [...chartData.m.names] },
   };

--- a/front/src/features/stats/redux/initialState.js
+++ b/front/src/features/stats/redux/initialState.js
@@ -10,6 +10,8 @@ const initialState = {
   getSessionsError: null,
   /** @type { import("@types").Session[] }*/
   sessions: [],
+  daysAgo: 0,
+  weeksAgo: 0,
 };
 
 export default initialState;

--- a/front/src/features/stats/redux/initialState.js
+++ b/front/src/features/stats/redux/initialState.js
@@ -12,6 +12,7 @@ const initialState = {
   sessions: [],
   daysAgo: 0,
   weeksAgo: 0,
+  monthsAgo: 0,
 };
 
 export default initialState;

--- a/front/src/features/stats/redux/navigateDays.js
+++ b/front/src/features/stats/redux/navigateDays.js
@@ -1,0 +1,34 @@
+import { bindActionCreators, createAction, createReducer } from '@reduxjs/toolkit';
+import initialState from './initialState';
+import { useDispatch, useSelector } from 'react-redux';
+const empty = { payload: '' };
+const noop = () => empty;
+// This is to prevent from click events ending as part of the action payload
+const nextDay = createAction('stats/next-day', noop);
+const previousDay = createAction('stats/previous-day', noop);
+/** @typedef {import('rootReducer').RootState} RootState */
+
+export function useNavigateDays() {
+  const dispatch = useDispatch();
+
+  const daysAgo = useSelector(
+    /**
+     * @param {RootState} state
+     */
+    state => state.stats.daysAgo,
+  );
+
+  return {
+    daysAgo,
+    ...bindActionCreators({ nextDay, previousDay }, dispatch),
+  };
+}
+
+export default createReducer(initialState, builder => {
+  builder.addCase(nextDay, state => {
+    state.daysAgo++;
+  });
+  builder.addCase(previousDay, state => {
+    state.daysAgo = Math.max(0, state.daysAgo - 1);
+  });
+});

--- a/front/src/features/stats/redux/navigateWeeks.js
+++ b/front/src/features/stats/redux/navigateWeeks.js
@@ -1,0 +1,35 @@
+import { bindActionCreators, createAction, createReducer } from '@reduxjs/toolkit';
+import initialState from './initialState';
+import { useDispatch, useSelector } from 'react-redux';
+
+const empty = { payload: '' };
+const noop = () => empty;
+// This is to prevent from click events ending as part of the action payload
+const nextWeek = createAction('stats/next-week', noop);
+const previousWeek = createAction('stats/previous-week', noop);
+/** @typedef {import('rootReducer').RootState} RootState */
+
+export function useNavigateWeeks() {
+  const dispatch = useDispatch();
+
+  const weeksAgo = useSelector(
+    /**
+     * @param {RootState} state
+     */
+    state => state.stats.weeksAgo,
+  );
+
+  return {
+    weeksAgo,
+    ...bindActionCreators({ nextWeek, previousWeek }, dispatch),
+  };
+}
+
+export default createReducer(initialState, builder => {
+  builder.addCase(nextWeek, state => {
+    state.weeksAgo++;
+  });
+  builder.addCase(previousWeek, state => {
+    state.weeksAgo = Math.max(0, state.weeksAgo - 1);
+  });
+});

--- a/front/src/features/stats/redux/reducer.js
+++ b/front/src/features/stats/redux/reducer.js
@@ -8,12 +8,20 @@
 
 import initialState from './initialState';
 import { reducer as getSessionsReducer } from './getSessions';
+import { default as navigateDaysReducer } from './navigateDays';
+import { default as navigateWeeksReducer } from './navigateWeeks';
 
-const reducers = [
-  getSessionsReducer,
-];
+const reducers = [getSessionsReducer, navigateDaysReducer, navigateWeeksReducer];
 
+/** @typedef {typeof import('./initialState').default} State  */
+
+/**
+ * @param {State} state
+ * @param {*} action
+ * @returns {State}
+ */
 export default function reducer(state = initialState, action) {
+  /** @type { State } */
   let newState;
   switch (action.type) {
     // Handle cross-topic actions here

--- a/front/src/features/stats/redux/selectDonutSessions.js
+++ b/front/src/features/stats/redux/selectDonutSessions.js
@@ -1,0 +1,46 @@
+/** @typedef {import("@types").Session} Session*/
+
+import { createSelector } from 'reselect';
+import selectRelativeDaysSessions from './selectRelativeDaysSessions';
+
+const msInADay = 864e5;
+/**
+ * @param {Date|string} start
+ * @param {Date|string} end
+ */
+function dateDiff(start, end = new Date()) {
+  return new Date(end).getTime() - new Date(start).getTime();
+}
+
+/**
+ * Reducer function that adds duration to a session and keeps
+ * track of the amount of unused milliseconds
+ * @param {{all: Map<string,{name: string, duration: number}>, unused: number}} param0
+ * @param {Session} session
+ */
+const addDurationToSessions = ({ all, unused }, session) => {
+  const duration = dateDiff(session.startDate, session.endDate);
+  const { name, duration: oldDuration = 0 } = all.get(session.name) || session;
+  all.set(name, { ...session, duration: oldDuration + duration });
+
+  return {
+    unused: unused - duration,
+    all,
+  };
+};
+
+/**
+ *
+ * @param {Session[]} sessions
+ * @returns {{name: string, duration: number}[]}
+ */
+function selectDonutSessions(sessions) {
+  const initialValue = { all: new Map(), unused: msInADay };
+  const { all, unused } = sessions.reduce(addDurationToSessions, initialValue);
+
+  const allSessions = Array.from(all, ([_, value]) => value);
+
+  return unused > 0 ? allSessions.concat([{ duration: unused, name: 'Unused' }]) : allSessions;
+}
+
+export default createSelector(selectRelativeDaysSessions, selectDonutSessions);

--- a/front/src/features/stats/redux/selectMonthChartData.js
+++ b/front/src/features/stats/redux/selectMonthChartData.js
@@ -1,0 +1,68 @@
+/** @typedef {import("@types").Session} Session*/
+
+import selectAllSessions from 'features/home/redux/selectAllSessions';
+import { createSelector } from 'reselect';
+import subMonths from 'date-fns/subMonths';
+import startOfMonth from 'date-fns/startOfMonth';
+import endOfMonth from 'date-fns/endOfMonth';
+import isWithinInterval from 'date-fns/isWithinInterval';
+import format from 'date-fns/fp/format';
+import { diffDateStrings } from 'features/home/redux/diffDateStrings';
+import endOfDay from 'date-fns/endOfDay';
+
+/**
+ * Given a number of months ago selects the sessions of that day.
+ * @param {Session[]} sessions
+ * @returns {Session[]}
+ */
+function selectRelativeMonthsSessions(sessions, monthsAgo = 0) {
+  const today = endOfDay(new Date());
+  const monthRef = subMonths(startOfMonth(today), monthsAgo);
+  const interval = { start: monthRef, end: endOfMonth(monthRef) };
+  return sessions.filter(({ startDate }) => isWithinInterval(new Date(startDate), interval));
+}
+
+const formatWeek = format('Io');
+
+/** @typedef {{ [name:string]: number}} WeekData */
+/** @typedef {{ [date:string]: WeekData}} SessionsByWeek */
+/**
+ *
+ * @param {Session[]} sessions
+ */
+function groupSessionsByWeek(sessions) {
+  /** @type { {names: Set<string>, sessionsByWeek: SessionsByWeek} } */
+  const initial = { names: new Set(), sessionsByWeek: {} };
+  const { names, sessionsByWeek } = sessions.reduce(
+    ({ names, sessionsByWeek }, { startDate, endDate, name }) => {
+      const dateStr = formatWeek(new Date(startDate));
+      names.add(name);
+      const dayData = sessionsByWeek[dateStr] || { [name]: 0, startDate };
+      const duration = diffDateStrings(startDate, endDate);
+
+      return {
+        names,
+        sessionsByWeek: {
+          ...sessionsByWeek,
+          [dateStr]: {
+            ...dayData,
+            [name]: (dayData[name] || 0) + duration,
+          },
+        },
+      };
+    },
+    initial,
+  );
+  return { names: Array.from(names), sessions: Object.values(sessionsByWeek) };
+}
+
+export const selectMonthSessions = createSelector(
+  selectAllSessions,
+  /**
+   * @param {import('rootReducer').RootState} state
+   */
+  state => state.stats.monthsAgo,
+  selectRelativeMonthsSessions,
+);
+
+export default createSelector(selectMonthSessions, groupSessionsByWeek);

--- a/front/src/features/stats/redux/selectMonthChartData.js
+++ b/front/src/features/stats/redux/selectMonthChartData.js
@@ -37,7 +37,7 @@ function groupSessionsByWeek(sessions) {
     ({ names, sessionsByWeek }, { startDate, endDate, name }) => {
       const dateStr = formatWeek(new Date(startDate));
       names.add(name);
-      const dayData = sessionsByWeek[dateStr] || { [name]: 0, startDate };
+      const dayData = sessionsByWeek[dateStr] || { [name]: 0, startDate: dateStr };
       const duration = diffDateStrings(startDate, endDate);
 
       return {

--- a/front/src/features/stats/redux/selectRelativeDaysSessions.js
+++ b/front/src/features/stats/redux/selectRelativeDaysSessions.js
@@ -1,0 +1,30 @@
+/** @typedef {import("@types").Session} Session*/
+
+import selectAllSessions from 'features/home/redux/selectAllSessions';
+import { createSelector } from 'reselect';
+import subDays from 'date-fns/subDays';
+import { isWithinInterval, startOfDay } from 'date-fns';
+import { endOfDay } from 'date-fns/esm';
+
+/**
+ * Given a number of days ago selects the sessions of that day.
+ * @param {Session[]} sessions
+ * @returns {Session[]}
+ */
+function selectRelativeDaysSessions(sessions, daysAgo = 0) {
+  const today = endOfDay(new Date());
+  const dayRef = subDays(today, daysAgo);
+  const interval = { start: startOfDay(dayRef), end: endOfDay(dayRef) };
+  return sessions.filter(({ startDate }) => isWithinInterval(new Date(startDate), interval));
+}
+
+export default createSelector(
+  selectAllSessions,
+  /**
+   * stupid function to provide the props to the selector
+   * @param {any} _
+   * @param {number} props the props from the component
+   */
+  (_, props) => props,
+  selectRelativeDaysSessions,
+);

--- a/front/src/features/stats/redux/selectRelativeDaysSessions.js
+++ b/front/src/features/stats/redux/selectRelativeDaysSessions.js
@@ -3,8 +3,9 @@
 import selectAllSessions from 'features/home/redux/selectAllSessions';
 import { createSelector } from 'reselect';
 import subDays from 'date-fns/subDays';
-import { isWithinInterval, startOfDay } from 'date-fns';
-import { endOfDay } from 'date-fns/esm';
+import endOfDay from 'date-fns/endOfDay';
+import startOfDay from 'date-fns/startOfDay';
+import isWithinInterval from 'date-fns/isWithinInterval';
 
 /**
  * Given a number of days ago selects the sessions of that day.

--- a/front/src/features/stats/redux/selectWeekChartData.js
+++ b/front/src/features/stats/redux/selectWeekChartData.js
@@ -37,7 +37,7 @@ function groupSessionsByDay(sessions) {
     ({ names, sessionsByDay }, { startDate, endDate, name }) => {
       const dateStr = formatDay(new Date(startDate));
       names.add(name);
-      const dayData = sessionsByDay[dateStr] || { [name]: 0, startDate };
+      const dayData = sessionsByDay[dateStr] || { [name]: 0, startDate: dateStr };
       const duration = diffDateStrings(startDate, endDate);
 
       return {

--- a/front/src/features/stats/redux/selectWeekChartData.js
+++ b/front/src/features/stats/redux/selectWeekChartData.js
@@ -1,0 +1,68 @@
+/** @typedef {import("@types").Session} Session*/
+
+import selectAllSessions from 'features/home/redux/selectAllSessions';
+import { createSelector } from 'reselect';
+import subWeeks from 'date-fns/subWeeks';
+import startOfWeek from 'date-fns/startOfWeek';
+import endOfWeek from 'date-fns/endOfWeek';
+import endOfDay from 'date-fns/endOfDay';
+import isWithinInterval from 'date-fns/isWithinInterval';
+import format from 'date-fns/fp/format';
+import { diffDateStrings } from 'features/home/redux/diffDateStrings';
+
+/**
+ * Given a number of weeks ago selects the sessions of that day.
+ * @param {Session[]} sessions
+ * @returns {Session[]}
+ */
+function selectRelativeWeeksSessions(sessions, weeksAgo = 0) {
+  const today = endOfDay(new Date());
+  const weekRef = subWeeks(startOfWeek(today), weeksAgo);
+  const interval = { start: weekRef, end: endOfWeek(weekRef) };
+  return sessions.filter(({ startDate }) => isWithinInterval(new Date(startDate), interval));
+}
+
+const formatDay = format('E do MMM');
+
+/** @typedef {{ [name:string]: number}} DayData */
+/** @typedef {{ [date:string]: DayData}} SessionsByDay */
+/**
+ *
+ * @param {Session[]} sessions
+ */
+function groupSessionsByDay(sessions) {
+  /** @type { {names: Set<string>, sessionsByDay: SessionsByDay} } */
+  const initial = { names: new Set(), sessionsByDay: {} };
+  const { names, sessionsByDay } = sessions.reduce(
+    ({ names, sessionsByDay }, { startDate, endDate, name }) => {
+      const dateStr = formatDay(new Date(startDate));
+      names.add(name);
+      const dayData = sessionsByDay[dateStr] || { [name]: 0, startDate };
+      const duration = diffDateStrings(startDate, endDate);
+
+      return {
+        names,
+        sessionsByDay: {
+          ...sessionsByDay,
+          [dateStr]: {
+            ...dayData,
+            [name]: (dayData[name] || 0) + duration,
+          },
+        },
+      };
+    },
+    initial,
+  );
+  return { names: Array.from(names), sessions: Object.values(sessionsByDay) };
+}
+
+export const selectWeekSessions = createSelector(
+  selectAllSessions,
+  /**
+   * @param {import('rootReducer').RootState} state
+   */
+  state => state.stats.weeksAgo,
+  selectRelativeWeeksSessions,
+);
+
+export default createSelector(selectWeekSessions, groupSessionsByDay);

--- a/front/src/formatters/formatDateDiff.js
+++ b/front/src/formatters/formatDateDiff.js
@@ -1,6 +1,6 @@
-import { differenceInMinutes } from 'date-fns';
 import { formatMinutes4Human } from './formatMinutes4Human';
 import format from 'date-fns/format';
+import differenceInMinutes from 'date-fns/differenceInMinutes';
 
 /** @typedef {Date|string|number} DateCompatible*/
 

--- a/front/src/types.d.ts
+++ b/front/src/types.d.ts
@@ -1,9 +1,24 @@
 export type Session = {
   name: string;
+  /**
+   * Iso date format
+   */
   startDate: string;
+  /**
+   * Iso date format
+   */
   endDate?: string;
   id: string;
 };
+
+export type SessionWithDuration = {
+  name: string;
+  startDate: string;
+  endDate?: string;
+  id: string;
+  duration: number;
+};
+
 export type RunningSession = {
   name: string;
   startDate: string;

--- a/front/tsconfig.json
+++ b/front/tsconfig.json
@@ -16,7 +16,7 @@
     "baseUrl": "./src",
     "paths": {
       "rootReducer": ["common/rootReducer"],
-      "common": ["common/*"],
+      "@common/*": ["common/*"],
       "formatters": ["formatters"],
       "@types": ["types"]
     }

--- a/front/yarn.lock
+++ b/front/yarn.lock
@@ -1730,6 +1730,16 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=
 
+"@reduxjs/toolkit@^1.5.1":
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/@reduxjs/toolkit/-/toolkit-1.5.1.tgz#05daa2f6eebc70dc18cd98a90421fab7fa565dc5"
+  integrity sha512-PngZKuwVZsd+mimnmhiOQzoD0FiMjqVks6ituO1//Ft5UEX5Ca9of13NEjo//pU22Jk7z/mdXVsmDfgsig1osA==
+  dependencies:
+    immer "^8.0.1"
+    redux "^4.0.0"
+    redux-thunk "^2.3.0"
+    reselect "^4.0.0"
+
 "@rollup/plugin-node-resolve@^7.1.1":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-7.1.3.tgz#80de384edfbd7bfc9101164910f86078151a3eca"
@@ -7196,6 +7206,11 @@ immer@1.10.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/immer/-/immer-1.10.0.tgz#bad67605ba9c810275d91e1c2a47d4582e98286d"
   integrity sha512-O3sR1/opvCDGLEVcvrGTMtLac8GJ5IwZC4puPrLuRj3l7ICKvkmA0vGuU9OW8mV9WIBRnaxp5GJh9IEAaNOoYg==
+
+immer@^8.0.1:
+  version "8.0.4"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-8.0.4.tgz#3a21605a4e2dded852fb2afd208ad50969737b7a"
+  integrity sha512-jMfL18P+/6P6epANRvRk6q8t+3gGhqsJ9EuJ25AXE+9bNTYtssvzeYbEd0mXRYWCmmXSIbnlpz6vd6iJlmGGGQ==
 
 "immutable@^3.8.1 || ^4.0.0-rc.1":
   version "4.0.0-rc.12"

--- a/front/yarn.lock
+++ b/front/yarn.lock
@@ -2018,6 +2018,14 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
+"@types/jest@^26.0.22":
+  version "26.0.22"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.22.tgz#8308a1debdf1b807aa47be2838acdcd91e88fbe6"
+  integrity sha512-eeWwWjlqxvBxc4oQdkueW5OF/gtfSceKk4OnOAGlUSwS/liBRtZppbJuz1YkgbrbfGOoeBHun9fOvXnjNwrSOw==
+  dependencies:
+    jest-diff "^26.0.0"
+    pretty-format "^26.0.0"
+
 "@types/json-schema@^7.0.5", "@types/json-schema@^7.0.6":
   version "7.0.7"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.7.tgz#98a993516c859eb0d5c4c8f098317a9ea68db9ad"
@@ -7959,7 +7967,7 @@ jest-config@^26.6.3:
     micromatch "^4.0.2"
     pretty-format "^26.6.2"
 
-jest-diff@^26.6.2:
+jest-diff@^26.0.0, jest-diff@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-26.6.2.tgz#1aa7468b52c3a68d7d5c5fdcdfcd5e49bd164394"
   integrity sha512-6m+9Z3Gv9wN0WFVasqjCL/06+EFCMTqDEUl/b87HYK2rAPTyfz4ZIuSlPhY51PIQRWx5TaxeF1qmXKe9gfN3sA==
@@ -10901,7 +10909,7 @@ pretty-error@^2.1.1:
     lodash "^4.17.20"
     renderkid "^2.0.4"
 
-pretty-format@^26.6.2:
+pretty-format@^26.0.0, pretty-format@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-26.6.2.tgz#e35c2705f14cb7fe2fe94fa078345b444120fc93"
   integrity sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==


### PR DESCRIPTION
A donut is better to show the today data because gives you a better relative information.
Previously we were showing a bar chart with groups per minute, which was very useless

Fixes #69 