### PR TITLE
fix(UI): get rid of material time picker

### DIFF
--- a/front/.vscode/settings.json
+++ b/front/.vscode/settings.json
@@ -1,3 +1,5 @@
 {
-  "files.associations": { "*.js": "javascript" }
+  "files.associations": {
+    "*.yaml": "home-assistant"
+  }
 }

--- a/front/src/features/home/EditSession/EditSession.js
+++ b/front/src/features/home/EditSession/EditSession.js
@@ -8,7 +8,8 @@ import Delete from '@material-ui/icons/Delete';
 import IconButton from '@material-ui/core/IconButton';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import Box from '@material-ui/core/Box';
-import { DatePicker, TimePicker } from '@material-ui/pickers';
+import { DatePicker } from '@material-ui/pickers';
+import TimePicker from './TimePicker';
 import Slider from '@material-ui/core/Slider';
 import Typography from '@material-ui/core/Typography';
 import { useState } from 'react';
@@ -68,23 +69,11 @@ function EditSession(props) {
       <DialogContent>
         <Box pb={4} display="flex">
           <DatePicker label="Started at date" value={date} onChange={setDate} variant="inline" />
-          <TimePicker
-            id="time-picker-start"
-            label="time"
-            value={date}
-            onChange={setDate}
-            ampm={false}
-          />
+          <TimePicker id="time-picker-start" label="time" value={date} onChange={setDate} />
         </Box>
         <Box display="flex">
           <DatePicker label="Finished at" value={dateEnd} onChange={setEndDate} variant="inline" />
-          <TimePicker
-            id="time-picker-end"
-            label="time"
-            value={dateEnd}
-            onChange={setEndDate}
-            ampm={false}
-          />
+          <TimePicker id="time-picker-end" label="time" value={dateEnd} onChange={setEndDate} />
         </Box>
         <Box pt={2}>
           <Typography id="discrete-slider" gutterBottom>

--- a/front/src/features/home/EditSession/TimePicker.js
+++ b/front/src/features/home/EditSession/TimePicker.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import TextField from '@material-ui/core/TextField';
+import { setHours, setMinutes, format } from 'date-fns';
+// https://codesandbox.io/s/ie3eh?file=/demo.js:0-900
+
+const useStyles = makeStyles(theme => ({
+  container: {
+    display: 'flex',
+    flexWrap: 'wrap',
+  },
+}));
+
+/**
+ *
+ *
+ * @param {Date} originalDate
+ * @param {string} dateString
+ * @return {Date}
+ */
+function parseDate(originalDate, dateString) {
+  const [hours, minutes] = dateString.split(':');
+  return setHours(setMinutes(originalDate, parseInt(minutes, 10)), parseInt(hours, 10));
+}
+
+/**
+ *
+ * @param {{value: Date, onChange: (d: Date) => any, id: string, label: string }} props
+ */
+export default function TimePickers({ value, onChange, id, label }) {
+  const classes = useStyles();
+
+  const formattedValue = format(value, 'HH:mm');
+
+  return (
+    <form className={classes.container} noValidate>
+      <TextField
+        id={id}
+        value={formattedValue}
+        onChange={e => onChange(parseDate(value, e.target.value))}
+        label={label}
+        type="time"
+        InputLabelProps={{
+          shrink: true,
+        }}
+        inputProps={{
+          step: 300, // 5 min
+        }}
+      />
+    </form>
+  );
+}


### PR DESCRIPTION
This removes the bloated and terrible material time picker.
Hopefully this will reduce the app size too (if tree shake works correctly)